### PR TITLE
Fix target folder parent directory check

### DIFF
--- a/file_filter.py
+++ b/file_filter.py
@@ -106,11 +106,12 @@ def main():
     if not os.path.exists(args.source):
         print(f"错误: 源文件夹不存在: {args.source}")
         return
-    
-    if not os.path.exists(os.path.dirname(args.target)):
-        print(f"错误: 目标文件夹的父目录不存在: {os.path.dirname(args.target)}")
+
+    target_parent = os.path.dirname(args.target)
+    if target_parent and not os.path.exists(target_parent):
+        print(f"错误: 目标文件夹的父目录不存在: {target_parent}")
         return
-    
+
     if not os.path.exists(args.reference):
         print(f"错误: 参考表格文件不存在: {args.reference}")
         return


### PR DESCRIPTION
## Summary
- Avoid false errors when target folder is given as a relative path by verifying parent directory only when one is specified

## Testing
- `python file_filter.py --source example_photos --target output_photos --reference example_reference.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a42fed3f1083209a6ce50049a3378d